### PR TITLE
[EAI-40] Chat sharing

### DIFF
--- a/convex/conversations.ts
+++ b/convex/conversations.ts
@@ -58,25 +58,33 @@ export const getByUuid = query({
       isBranched: v.optional(v.boolean()),
       branchedFrom: v.optional(v.id("conversations")),
       branchedFromTitle: v.optional(v.string()),
+      isPublic: v.optional(v.boolean()),
     }),
     v.null()
   ),
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) {
-      return null;
-    }
-
     const conversation = await ctx.db
       .query("conversations")
       .withIndex("by_uuid", (q) => q.eq("uuid", args.uuid))
       .first();
     
-    if (!conversation || conversation.userId !== identity.subject) {
+    if (!conversation) {
       return null;
     }
 
-    return conversation;
+    // Allow access if:
+    // 1. User is authenticated and owns the conversation
+    // 2. Conversation is public
+    if (identity && conversation.userId === identity.subject) {
+      return conversation;
+    }
+    
+    if (conversation.isPublic) {
+      return conversation;
+    }
+
+    return null;
   },
 });
 
@@ -97,6 +105,7 @@ export const getById = query({
       isBranched: v.optional(v.boolean()),
       branchedFrom: v.optional(v.id("conversations")),
       branchedFromTitle: v.optional(v.string()),
+      isPublic: v.optional(v.boolean()),
     }),
     v.null()
   ),
@@ -128,6 +137,7 @@ export const list = query({
       createdAt: v.number(),
       updatedAt: v.number(),
       lastMessageAt: v.number(),
+      isPublic: v.optional(v.boolean()),
     }),
   ),
   handler: async (ctx) => {
@@ -160,10 +170,16 @@ export const listWithLastMessage = query({
       isBranched: v.optional(v.boolean()),
       branchedFrom: v.optional(v.id("conversations")),
       branchedFromTitle: v.optional(v.string()),
+      // Add isPublic field
+      isPublic: v.optional(v.boolean()),
+      // Add ownerName field
+      ownerName: v.optional(v.string()),
       // Keep lastMessage as is
       lastMessage: v.union(
         v.object({
           role: v.union(v.literal(MESSAGE_ROLES.USER), v.literal(MESSAGE_ROLES.ASSISTANT), v.literal(MESSAGE_ROLES.SYSTEM), v.literal(MESSAGE_ROLES.DATA)),
+          content: v.string(),
+          createdAt: v.number(),
           isComplete: v.optional(v.boolean()),
         }),
         v.null()
@@ -189,12 +205,27 @@ export const listWithLastMessage = query({
           .withIndex("by_conversation_and_created", (q) => q.eq("conversationId", conversation._id))
           .order("desc")
           .first(); 
-        
+        // Try to get the user's name from Clerk identity or users table
+        let ownerName: string | undefined = undefined;
+        // Try to get from users table if it exists
+        // (If you have a users table, uncomment the following lines)
+        // const userDoc = await ctx.db
+        //   .query("users")
+        //   .withIndex("by_userId", (q) => q.eq("userId", conversation.userId))
+        //   .first();
+        // if (userDoc && userDoc.name) {
+        //   ownerName = userDoc.name;
+        // }
+        // Otherwise, fallback to Clerk identity (if this is the current user)
+        if (conversation.userId === identity.subject && identity.name) {
+          ownerName = identity.name;
+        }
         return {
           ...conversation,
           lastMessage: lastMessage
-            ? { role: lastMessage.role, isComplete: lastMessage.isComplete }
+            ? { role: lastMessage.role, isComplete: lastMessage.isComplete, content: lastMessage.content, createdAt: lastMessage.createdAt }
             : null,
+          ownerName,
         };
       })
     );
@@ -398,5 +429,30 @@ export const get = query({
     }
 
     return conversation;
+  },
+});
+
+export const togglePublic = mutation({
+  args: {
+    conversationId: v.id("conversations"),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, { conversationId }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Must be authenticated to toggle conversation visibility");
+    }
+
+    const conversation = await ctx.db.get(conversationId);
+    if (!conversation || conversation.userId !== identity.subject) {
+      throw new Error("Not authorised to modify this conversation");
+    }
+
+    const newIsPublic = !conversation.isPublic;
+    await ctx.db.patch(conversationId, {
+      isPublic: newIsPublic,
+    });
+
+    return newIsPublic;
   },
 }); 

--- a/convex/conversations.ts
+++ b/convex/conversations.ts
@@ -207,16 +207,7 @@ export const listWithLastMessage = query({
           .first(); 
         // Try to get the user's name from Clerk identity or users table
         let ownerName: string | undefined = undefined;
-        // Try to get from users table if it exists
-        // (If you have a users table, uncomment the following lines)
-        // const userDoc = await ctx.db
-        //   .query("users")
-        //   .withIndex("by_userId", (q) => q.eq("userId", conversation.userId))
-        //   .first();
-        // if (userDoc && userDoc.name) {
-        //   ownerName = userDoc.name;
-        // }
-        // Otherwise, fallback to Clerk identity (if this is the current user)
+
         if (conversation.userId === identity.subject && identity.name) {
           ownerName = identity.name;
         }

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -187,19 +187,32 @@ export const list = query({
   ),
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) {
-        return [];
-    }
     const conversation = await ctx.db.get(args.conversationId);
-    if (!conversation || conversation.userId !== identity.subject) {
+    
+    if (!conversation) {
       return [];
     }
 
-    return await ctx.db
-      .query("messages")
-      .withIndex("by_conversation_and_created", (q) => q.eq("conversationId", args.conversationId))
-      .order("asc")
-      .collect();
+    // Allow access if:
+    // 1. User is authenticated and owns the conversation
+    // 2. Conversation is public
+    if (identity && conversation.userId === identity.subject) {
+      return await ctx.db
+        .query("messages")
+        .withIndex("by_conversation_and_created", (q) => q.eq("conversationId", args.conversationId))
+        .order("asc")
+        .collect();
+    }
+    
+    if (conversation.isPublic) {
+      return await ctx.db
+        .query("messages")
+        .withIndex("by_conversation_and_created", (q) => q.eq("conversationId", args.conversationId))
+        .order("asc")
+        .collect();
+    }
+
+    return [];
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -48,6 +48,7 @@ export default defineSchema({
     isBranched: v.optional(v.boolean()),
     branchedFrom: v.optional(v.id("conversations")),
     branchedFromTitle: v.optional(v.string()),
+    isPublic: v.optional(v.boolean()), // Whether this conversation is publicly shareable
   })
     .index("by_user", ["userId"])
     .index("by_user_and_last_message", ["userId", "lastMessageAt"])

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -25,22 +25,22 @@ export default function Chat({ threadId: initialThreadUuid }: ChatProps) {
   const scrollContainerRef = useRef<HTMLElement>(null)
 
   // Find the Convex thread ID from the URL's UUID.
-  const existingThread = useConversationByUuid(isAuthenticated ? initialThreadUuid : undefined)
+  const existingThread = useConversationByUuid(initialThreadUuid)
   
   useEffect(() => {
-    if (isAuthenticated && existingThread) {
+    if (existingThread) {
       setConvexConversationId(existingThread._id);
     } else {
       setConvexConversationId(null);
     }
-  }, [isAuthenticated, existingThread, initialThreadUuid]);
+  }, [existingThread, initialThreadUuid]);
 
   // Reactively fetch messages for the current thread from Convex.
-  const convexMessages = useMessagesByUuid(isAuthenticated ? initialThreadUuid : undefined)
+  const convexMessages = useMessagesByUuid(initialThreadUuid)
 
   // Memoize the conversion from Convex doc format to the UI's UIMessage format.
   const messages: UIMessage[] = useMemo(() => {
-    if (!isAuthenticated || !convexMessages) return []
+    if (!convexMessages) return []
     return convexMessages.map((msg) => {
       const data: Record<string, any> = {
         isComplete: msg.isComplete ?? true,
@@ -104,7 +104,7 @@ export default function Chat({ threadId: initialThreadUuid }: ChatProps) {
         data,
       };
     })
-  }, [convexMessages, isAuthenticated])
+  }, [convexMessages])
 
   // Count tokens in messages and update store
   useTokenCounter(messages);
@@ -138,21 +138,25 @@ export default function Chat({ threadId: initialThreadUuid }: ChatProps) {
               />
             </div>
             
-            {/* Sticky ChatInput at bottom */}
-            <div className="sticky bottom-0 pb-4">
-              <ChatInput
-                threadId={initialThreadUuid}
-                convexConversationId={convexConversationId}
-                onConvexConversationIdChange={setConvexConversationId}
-                isStreaming={isStreaming}
-              />
-            </div>
+            {/* Sticky ChatInput at bottom - only show if authenticated or public */}
+            {isAuthenticated && (
+              <div className="sticky bottom-0 pb-4">
+                <ChatInput
+                  threadId={initialThreadUuid}
+                  convexConversationId={convexConversationId}
+                  onConvexConversationIdChange={setConvexConversationId}
+                  isStreaming={isStreaming}
+                />
+              </div>
+            )}
           </div>
         </main>
       </div>
       
-      {/* Settings panel - shifts content on desktop, overlays on mobile */}
-      <ChatRunSettings conversationId={convexConversationId} messages={messages} />
+      {/* Settings panel - only show if authenticated */}
+      {isAuthenticated && (
+        <ChatRunSettings conversationId={convexConversationId} messages={messages} />
+      )}
     </div>
   )
 }

--- a/frontend/components/ChatSidebar.tsx
+++ b/frontend/components/ChatSidebar.tsx
@@ -15,12 +15,13 @@ import {
 import { useIsMobile } from "@/hooks/use-mobile"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Link, useNavigate, useLocation } from "react-router-dom"
-import { X, Plus, Settings, ChevronLeft, ChevronRight, MessageSquare, LogIn, Loader2, GitFork } from "lucide-react"
+import { X, Plus, Settings, ChevronLeft, ChevronRight, MessageSquare, LogIn, Loader2, GitFork, Globe } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { memo } from "react"
-import { Authenticated, Unauthenticated, useConvexAuth } from "convex/react"
+import { Authenticated, Unauthenticated, useConvexAuth, useQuery } from "convex/react"
 import { SignInButton, UserButton, useUser } from "@clerk/nextjs"
 import { useConversations, useDeleteConversation } from "@/lib/convex-hooks"
+import type { Conversation } from "@/lib/convex-storage"
 import { convertConvexConversation } from "@/lib/convex-storage"
 import type { Id } from "@/convex/_generated/dataModel"
 import { ROUTES } from "@/frontend/constants/routes"
@@ -31,6 +32,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { api } from "@/convex/_generated/api"
 // A simple spinner component for the sidebar.
 const StreamingSpinner = () => (
   <Loader2 size={16} className="animate-spin text-primary" />
@@ -49,7 +51,7 @@ export default function ChatSidebar() {
   const deleteConversationMutation = useDeleteConversation()
 
   // Convert Convex conversations to app format - but keep the original data for streaming check
-  const conversations = React.useMemo(() => {
+  const conversations: Conversation[] = React.useMemo(() => {
     if (!isAuthenticated || !convexConversations) return []
     return convexConversations.map(convertConvexConversation)
   }, [convexConversations, isAuthenticated])
@@ -151,37 +153,51 @@ export default function ChatSidebar() {
                 <TooltipProvider delayDuration={100}>
                   <SidebarMenu className="space-y-1">
                     {conversations?.map((conversation) => {
+                      console.log("Conversation ID:", conversation.id, "UUID:", conversation.uuid);
                       // Logic for streaming state
                       const isStreaming = conversation.lastMessage?.role === MESSAGE_ROLES.ASSISTANT && conversation.lastMessage.isComplete === false;
                       
                       return (
                         <SidebarMenuItem key={conversation.id}>
-                          <div
+                          <Link
+                            to={ROUTES.CHAT_THREAD(conversation.uuid)}
                             className={cn(
                               "cursor-pointer group/thread h-10 flex items-center px-2 py-2 rounded-lg overflow-hidden w-full transition-colors hover:bg-primary/10",
                               currentConversationId === conversation.id && "bg-primary/15",
                             )}
-                            onClick={() => {
-                              if (currentConversationId === conversation.id) {
-                                return
-                              }
-                              navigate(ROUTES.CHAT_THREAD(conversation.id))
-                            }}
                           >
-                            {conversation.isBranched && (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <GitFork className="h-4 w-4 mr-2 text-muted-foreground flex-shrink-0" />
-                                </TooltipTrigger>
-                                <TooltipContent side="right">
-                                  <p>Branched from '{conversation.branchedFromTitle}'</p>
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                            <span className="truncate text-sm font-medium flex-1">{conversation.title}</span>
-                            
-                            {isStreaming ? (
+                            <div className="flex-1 min-w-0">
                               <div className="flex items-center gap-2">
+                                <span className="truncate text-sm font-medium">{conversation.title}</span>
+                                {conversation.isBranched && (
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <GitFork className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                                    </TooltipTrigger>
+                                    <TooltipContent side="right">
+                                      <p>Branched from '{conversation.branchedFromTitle}'</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                )}
+                                {conversation.isPublic && (
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Globe className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                                    </TooltipTrigger>
+                                    <TooltipContent side="right">
+                                      <p>Shared by {conversation.ownerName || "an anonymous user"}</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                )}
+                              </div>
+                              <p className="text-xs text-muted-foreground truncate">
+                                {conversation.lastMessage?.content ||
+                                 (conversation.isPublic && conversation.ownerName ? `Shared by ${conversation.ownerName}` : "No messages")}
+                              </p>
+                            </div>
+
+                            {isStreaming ? (
+                              <div className="flex items-center gap-2 ml-2">
                                 <StreamingSpinner />
                               </div>
                             ) : (
@@ -194,7 +210,7 @@ export default function ChatSidebar() {
                                 <X size={14} />
                               </Button>
                             )}
-                          </div>
+                          </Link>
                         </SidebarMenuItem>
                       )
                     })}

--- a/frontend/components/ChatSidebar.tsx
+++ b/frontend/components/ChatSidebar.tsx
@@ -190,10 +190,6 @@ export default function ChatSidebar() {
                                   </Tooltip>
                                 )}
                               </div>
-                              <p className="text-xs text-muted-foreground truncate">
-                                {conversation.lastMessage?.content ||
-                                 (conversation.isPublic && conversation.ownerName ? `Shared by ${conversation.ownerName}` : "No messages")}
-                              </p>
                             </div>
 
                             {isStreaming ? (

--- a/frontend/lib/convex-hooks.ts
+++ b/frontend/lib/convex-hooks.ts
@@ -1,0 +1,3 @@
+import type { Id } from "@/convex/_generated/dataModel";
+
+// Removed Conversation type definition from here. 

--- a/lib/convex-storage.ts
+++ b/lib/convex-storage.ts
@@ -3,22 +3,26 @@ import type { Id } from "@/convex/_generated/dataModel";
 import { type MessageRole } from "@/convex/constants";
 import { v } from "convex/values";
 import type { MessagePart } from "@/convex/types";
-import type { useConversations } from "./convex-hooks";
 
-export interface Conversation {
+export type Conversation = {
   _id: Id<"conversations">;
-  id: string; // This is the UUID
+  id: string;
+  uuid: string;
   title: string;
   createdAt: Date;
   updatedAt: Date;
   lastMessageAt: Date;
-  isBranched?: boolean;
-  branchedFromTitle?: string;
   lastMessage?: {
-    role: MessageRole;
+    content: string;
+    createdAt: number;
+    role?: string;
     isComplete?: boolean;
   } | null;
-}
+  isPublic?: boolean;
+  isBranched?: boolean;
+  branchedFromTitle?: string;
+  ownerName?: string;
+};
 
 export interface DBMessage {
   _id: Id<"messages">;
@@ -39,7 +43,27 @@ export interface MessageSummary {
 }
 
 // This type represents one item from the array returned by `api.conversations.listWithLastMessage`
-type ConvexConversationWithDetails = NonNullable<ReturnType<typeof useConversations>>[number];
+type ConvexConversationWithDetails = {
+  _id: Id<"conversations">;
+  _creationTime: number;
+  uuid: string;
+  title: string;
+  userId: string;
+  createdAt: number;
+  updatedAt: number;
+  lastMessageAt: number;
+  isBranched?: boolean;
+  branchedFrom?: Id<"conversations">;
+  branchedFromTitle?: string;
+  isPublic?: boolean;
+  ownerName?: string;
+  lastMessage?: {
+    role: MessageRole;
+    content: string;
+    createdAt: number;
+    isComplete?: boolean;
+  } | null;
+};
 
 // Convert Convex conversation to app conversation format
 export function convertConvexConversation(
@@ -47,7 +71,8 @@ export function convertConvexConversation(
 ): Conversation {
   return {
     _id: convexConversation._id,
-    id: convexConversation.uuid, // Use UUID as the id for URL routing
+    id: convexConversation.uuid,
+    uuid: convexConversation.uuid,
     title: convexConversation.title,
     createdAt: new Date(convexConversation.createdAt),
     updatedAt: new Date(convexConversation.updatedAt),
@@ -55,6 +80,8 @@ export function convertConvexConversation(
     lastMessage: convexConversation.lastMessage,
     isBranched: convexConversation.isBranched,
     branchedFromTitle: convexConversation.branchedFromTitle,
+    isPublic: convexConversation.isPublic,
+    ownerName: convexConversation.ownerName,
   };
 }
 


### PR DESCRIPTION
**Description:**
This PR introduces the ability to share chat conversations via a public link, accessible to both authenticated and unauthenticated users. It also refines the chat history sidebar UI to clearly indicate shared and branched conversations, including who shared them. Extensive work was done to ensure robust type consistency across the frontend and Convex backend.

**Key Changes:**

*   **Shareable Conversations Backend:**
    *   Added `isPublic` field to `conversations` and implemented a `togglePublic` mutation.
    *   Updated backend queries (`getByUuid`, `listWithLastMessage`) to support public access and include `ownerName`.
*   **Enhanced Chat History Sidebar:**
    *   Displays a globe icon (🌐) and "Shared by [Owner Name]" for public conversations, similar to the branching indicator.
    *   Improved tooltips for shared chats and ensured correct navigation.
*   **Share Controls:** The share button now dynamically shows "Share conversation" or "Make private".
*   **Type System Refinements:** Consolidated the `Conversation` type definition, ensuring accurate data mapping and resolving previous type mismatches.

**How to Test:**

1.  Start local development servers:
    ```bash
    bunx convex dev
    bun run dev
    ```
2.  Create/open a chat, then use the "Share" button.
3.  Verify the globe icon, "Shared by" text, and tooltip appear in the sidebar for shared conversations.
4.  Test the copied public link in an incognito window to confirm read-only access.
5.  Try making a conversation private and observe the UI updates.
6.  Ensure existing branched conversations still display correctly alongside shared ones.



![image](https://github.com/user-attachments/assets/76471d28-a581-43af-b926-7a5c01062db0)
